### PR TITLE
rename `consumable_only` to `include_delayed`

### DIFF
--- a/docs/worker/methods/number_of_enqueued_tasks.md
+++ b/docs/worker/methods/number_of_enqueued_tasks.md
@@ -1,6 +1,6 @@
 # Worker - number_of_enqueued_tasks
 
-The `number_of_enqueued_tasks` method return the number of all the tasks from the queue. Unless `task_name` was specified, uses the current worker name. `consumable_only` means whether to count only consumable tasks, that are not delayed for future execution or to count those too. A good reason to use `consumable_only` parameter is when you implement an autoscaler, and you want to upscale the number of workers based on the number of consumable tasks rather than the number of tasks along with the delayed tasks.
+The `number_of_enqueued_tasks` method return the number of all the tasks from the queue. Unless `task_name` was specified, uses the current worker name. `include_delayed` means whether to count delayed tasks too. A good reason to use `include_delayed` parameter is when you implement an autoscaler, and you want to upscale the number of workers based on the number of consumable tasks rather than the number of tasks along with the delayed tasks.
 
 
 ## Definition
@@ -9,7 +9,7 @@ The `number_of_enqueued_tasks` method return the number of all the tasks from th
 def number_of_enqueued_tasks(
     self,
     task_name: typing.Optional[str] = None,
-    consumable_only: bool = False,
+    include_delayed: bool = False,
 ) -> typing.Optional[int]
 ```
 

--- a/sergeant/broker.py
+++ b/sergeant/broker.py
@@ -25,11 +25,11 @@ class Broker:
     def number_of_enqueued_tasks(
         self,
         task_name: str,
-        consumable_only: bool,
+        include_delayed: bool,
     ) -> int:
         number_of_enqueued_tasks = self.connector.queue_length(
             queue_name=task_name,
-            consumable_only=consumable_only,
+            include_delayed=include_delayed,
         )
 
         return number_of_enqueued_tasks

--- a/sergeant/connector/_connector.py
+++ b/sergeant/connector/_connector.py
@@ -88,7 +88,7 @@ class Connector:
     def queue_length(
         self,
         queue_name: str,
-        consumable_only: bool,
+        include_delayed: bool,
     ) -> int:
         raise NotImplementedError()
 

--- a/sergeant/connector/mongo.py
+++ b/sergeant/connector/mongo.py
@@ -405,24 +405,24 @@ class Connector(
     def queue_length(
         self,
         queue_name: str,
-        consumable_only: bool,
+        include_delayed: bool,
     ) -> int:
         queue_length = 0
 
         for i in range(self.number_of_connections):
-            if consumable_only:
+            if include_delayed:
                 queue_length += self.next_connection.sergeant.task_queue.count_documents(
                     filter={
                         'queue_name': queue_name,
-                        'priority': {
-                            '$lte': int(time.time()),
-                        },
                     },
                 )
             else:
                 queue_length += self.next_connection.sergeant.task_queue.count_documents(
                     filter={
                         'queue_name': queue_name,
+                        'priority': {
+                            '$lte': int(time.time()),
+                        },
                     },
                 )
 

--- a/sergeant/connector/redis.py
+++ b/sergeant/connector/redis.py
@@ -182,9 +182,16 @@ class QueueRedis(
     def queue_length(
         self,
         queue_name: str,
-        consumable_only: bool,
+        include_delayed: bool,
     ):
-        if consumable_only:
+        if include_delayed:
+            return self.queue_length_script(
+                keys=[
+                    queue_name,
+                ],
+                args=[],
+            )
+        else:
             return self.queue_length_script(
                 keys=[
                     queue_name,
@@ -192,13 +199,6 @@ class QueueRedis(
                 args=[
                     int(time.time()),
                 ],
-            )
-        else:
-            return self.queue_length_script(
-                keys=[
-                    queue_name,
-                ],
-                args=[],
             )
 
     def queue_delete(
@@ -390,14 +390,14 @@ class Connector(
     def queue_length(
         self,
         queue_name: str,
-        consumable_only: bool,
+        include_delayed: bool,
     ) -> int:
         queue_length = 0
 
         for connection in self.connections:
             queue_length += connection.queue_length(
                 queue_name=queue_name,
-                consumable_only=consumable_only,
+                include_delayed=include_delayed,
             )
 
         return queue_length

--- a/sergeant/worker.py
+++ b/sergeant/worker.py
@@ -111,12 +111,12 @@ class Worker:
     def number_of_enqueued_tasks(
         self,
         task_name: typing.Optional[str] = None,
-        consumable_only: bool = False,
+        include_delayed: bool = False,
     ) -> typing.Optional[int]:
         try:
             return self.broker.number_of_enqueued_tasks(
                 task_name=task_name if task_name else self.config.name,
-                consumable_only=consumable_only,
+                include_delayed=include_delayed,
             )
         except Exception as exception:
             self.logger.error(

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='sergeant',
-    version='0.15.2',
+    version='0.16.0',
     author='Gal Ben David',
     author_email='gal@intsights.com',
     url='https://github.com/Intsights/sergeant',

--- a/tests/broker/test_broker.py
+++ b/tests/broker/test_broker.py
@@ -27,7 +27,7 @@ class BrokerTestCase:
         self.assertEqual(
             first=self.test_broker.number_of_enqueued_tasks(
                 task_name='test_task',
-                consumable_only=True,
+                include_delayed=False,
             ),
             second=0,
         )
@@ -40,7 +40,7 @@ class BrokerTestCase:
         self.assertEqual(
             first=self.test_broker.number_of_enqueued_tasks(
                 task_name='test_task',
-                consumable_only=True,
+                include_delayed=False,
             ),
             second=1,
         )
@@ -50,7 +50,7 @@ class BrokerTestCase:
         self.assertEqual(
             first=self.test_broker.number_of_enqueued_tasks(
                 task_name='test_task',
-                consumable_only=True,
+                include_delayed=False,
             ),
             second=0,
         )
@@ -75,14 +75,14 @@ class BrokerTestCase:
         self.assertEqual(
             first=self.test_broker.number_of_enqueued_tasks(
                 task_name='test_task',
-                consumable_only=True,
+                include_delayed=False,
             ),
             second=2,
         )
         self.assertEqual(
             first=self.test_broker.number_of_enqueued_tasks(
                 task_name='test_task',
-                consumable_only=False,
+                include_delayed=True,
             ),
             second=3,
         )
@@ -92,7 +92,7 @@ class BrokerTestCase:
         self.assertEqual(
             first=self.test_broker.number_of_enqueued_tasks(
                 task_name='test_task',
-                consumable_only=False,
+                include_delayed=True,
             ),
             second=0,
         )
@@ -134,14 +134,14 @@ class BrokerTestCase:
         self.assertEqual(
             first=self.test_broker.number_of_enqueued_tasks(
                 task_name='test_task',
-                consumable_only=True,
+                include_delayed=False,
             ),
             second=20,
         )
         self.assertEqual(
             first=self.test_broker.number_of_enqueued_tasks(
                 task_name='test_task',
-                consumable_only=False,
+                include_delayed=True,
             ),
             second=30,
         )
@@ -151,7 +151,7 @@ class BrokerTestCase:
         self.assertEqual(
             first=self.test_broker.number_of_enqueued_tasks(
                 task_name='test_task',
-                consumable_only=False,
+                include_delayed=True,
             ),
             second=0,
         )
@@ -348,7 +348,7 @@ class BrokerTestCase:
             self.assertEqual(
                 first=test_broker.number_of_enqueued_tasks(
                     task_name='test_task',
-                    consumable_only=True,
+                    include_delayed=False,
                 ),
                 second=8,
             )

--- a/tests/connector/test_connector.py
+++ b/tests/connector/test_connector.py
@@ -90,7 +90,7 @@ class ConnectorTestCase:
         )
         queue_length = self.connector.queue_length(
             queue_name=self.test_queue_name,
-            consumable_only=True,
+            include_delayed=False,
         )
         self.assertEqual(
             first=queue_length,
@@ -104,7 +104,7 @@ class ConnectorTestCase:
         )
         queue_length = self.connector.queue_length(
             queue_name=self.test_queue_name,
-            consumable_only=True,
+            include_delayed=False,
         )
         self.assertEqual(
             first=queue_length,
@@ -115,7 +115,7 @@ class ConnectorTestCase:
         )
         queue_length = self.connector.queue_length(
             queue_name=self.test_queue_name,
-            consumable_only=True,
+            include_delayed=False,
         )
         self.assertEqual(
             first=queue_length,
@@ -206,7 +206,7 @@ class ConnectorTestCase:
         )
         queue_length = self.connector.queue_length(
             queue_name=self.test_queue_name,
-            consumable_only=True,
+            include_delayed=False,
         )
         self.assertEqual(
             first=queue_length,
@@ -218,7 +218,7 @@ class ConnectorTestCase:
         )
         queue_length = self.connector.queue_length(
             queue_name=self.test_queue_name,
-            consumable_only=True,
+            include_delayed=False,
         )
         self.assertEqual(
             first=queue_length,
@@ -425,7 +425,7 @@ class ConnectorTestCase:
         )
         queue_length = self.connector.queue_length(
             queue_name=self.test_queue_name,
-            consumable_only=True,
+            include_delayed=False,
         )
         self.assertEqual(
             first=queue_length,
@@ -439,7 +439,7 @@ class ConnectorTestCase:
         )
         queue_length = self.connector.queue_length(
             queue_name=self.test_queue_name,
-            consumable_only=True,
+            include_delayed=False,
         )
         self.assertEqual(
             first=queue_length,
@@ -460,7 +460,7 @@ class ConnectorTestCase:
         )
         queue_length = self.connector.queue_length(
             queue_name=self.test_queue_name,
-            consumable_only=True,
+            include_delayed=False,
         )
         self.assertEqual(
             first=queue_length,
@@ -468,7 +468,7 @@ class ConnectorTestCase:
         )
         queue_length = self.connector.queue_length(
             queue_name=self.test_queue_name,
-            consumable_only=False,
+            include_delayed=True,
         )
         self.assertEqual(
             first=queue_length,
@@ -480,7 +480,7 @@ class ConnectorTestCase:
         )
         queue_length = self.connector.queue_length(
             queue_name=self.test_queue_name,
-            consumable_only=True,
+            include_delayed=False,
         )
         self.assertEqual(
             first=queue_length,
@@ -488,7 +488,7 @@ class ConnectorTestCase:
         )
         queue_length = self.connector.queue_length(
             queue_name=self.test_queue_name,
-            consumable_only=False,
+            include_delayed=True,
         )
         self.assertEqual(
             first=queue_length,
@@ -529,7 +529,7 @@ class ConnectorTestCase:
         )
         queue_length = self.connector.queue_length(
             queue_name=self.test_queue_name,
-            consumable_only=True,
+            include_delayed=False,
         )
         self.assertEqual(
             first=queue_length,
@@ -537,7 +537,7 @@ class ConnectorTestCase:
         )
         queue_length = self.connector.queue_length(
             queue_name=self.test_queue_name,
-            consumable_only=False,
+            include_delayed=True,
         )
         self.assertEqual(
             first=queue_length,


### PR DESCRIPTION
`consumable_only` is a hard terminology for its purpose. I find `include_delayed` to be more readable, understandable, and intuitive.