### PR TITLE
Replace emitter["filename"] with emitter["pathname"]

### DIFF
--- a/sergeant/logging/logstash.py
+++ b/sergeant/logging/logstash.py
@@ -63,7 +63,7 @@ class LogstashHandler(
             'emitter': {
                 'hostname': self.hostname,
                 'ipaddress': self.ipaddress,
-                'filename': record.filename,
+                'pathname': record.pathname,
                 'function': record.funcName,
                 'line': record.lineno,
             },

--- a/tests/logging/test_logstash.py
+++ b/tests/logging/test_logstash.py
@@ -1,0 +1,50 @@
+import logging
+import unittest
+import unittest.mock
+
+import sergeant.logging.logstash
+
+
+@unittest.mock.patch.object(
+    target=sergeant.logging.logstash,
+    attribute='orjson',
+)
+@unittest.mock.patch.object(
+    target=sergeant.logging.logstash,
+    attribute='socket',
+)
+class LoggingLogstashTestCase(
+    unittest.TestCase,
+):
+    def setUp(
+        self,
+    ):
+        handler = sergeant.logging.logstash.LogstashHandler(
+            host='localhost',
+            port=9999,
+        )
+
+        self.logger = logging.Logger(
+            name='logger',
+        )
+
+        self.logger.addHandler(
+            hdlr=handler,
+        )
+
+    def test_mesage_includes_emitter_pathname(
+        self,
+        socket_mock,
+        orjson_mock,
+    ):
+        self.logger.info(
+            msg='test',
+        )
+
+        message = orjson_mock.dumps.call_args.args[0]
+
+        self.assertEqual(
+            first=message['emitter']['pathname'],
+            second=__file__,
+        )
+


### PR DESCRIPTION
Replaces the `emitter["filename"]` attribute in
sergeant.logging.logstash.LogstashHandler#emit` method with
`emitter["pathname"]` to include the full file path instead of the just
the filename.