### PR TITLE
Feature: Adding hanging threads protection and Slave's summary refactoring

### DIFF
--- a/examples/8_multiple_slaves_stop/README.md
+++ b/examples/8_multiple_slaves_stop/README.md
@@ -26,7 +26,6 @@ python3 -m examples.8_multiple_slaves_stop.producer
 ```
 
 ### Output
-You can see in logs that the delayed task has been consumed in a 5 seconds delay
 ```
 2021-02-09 15:24:17 Supervisor   671757 INFO     spawned a new worker at pid: 671758
 2021-02-09 15:24:17 Supervisor   671757 INFO     spawned a new worker at pid: 671759

--- a/examples/9_hanging_threads/README.md
+++ b/examples/9_hanging_threads/README.md
@@ -1,0 +1,41 @@
+## Description
+This example demonstrates how an infinite thread is stopped by the slave threading guard
+
+## Usage
+
+### Broker docker run
+```shell
+docker run \
+    --rm \
+    --detach \
+    --publish=6379:6379 \
+    redis
+```
+
+### Spawn a supervisor to spawn the consumers
+```shell
+python3 -m sergeant.supervisor \
+    --worker-module=examples.9_hanging_threads.consumer \
+    --worker-class=Worker \
+    --concurrent-worker=1
+```
+
+### Produce the tasks via the producer
+```shell
+python3 -m examples.9_hanging_threads.producer
+```
+
+### Output
+```
+2021-02-15 19:52:28 Supervisor   2655520 INFO     spawned a new worker at pid: 2655521
+2021-02-15 19:52:28 test_worker  2655521 INFO     param: first
+2021-02-15 19:52:28 test_worker  2655521 INFO     killable thread: 1613411548.4122536
+2021-02-15 19:52:28 test_worker  2655521 INFO     unkillable thread: 1613411548.4124434
+2021-02-15 19:52:29 test_worker  2655521 INFO     Got a SystemExit. Exiting...
+2021-02-15 19:52:29 test_worker  2655521 INFO     unkillable thread: 1613411549.4139714
+2021-02-15 19:52:30 test_worker  2655521 INFO     Got a SystemExit. Ignoring...
+2021-02-15 19:52:30 test_worker  2655521 INFO     unkillable thread: 1613411550.4157887
+2021-02-15 19:52:31 Supervisor   2655520 WARNING  worker(2655521) had unkillable_threads: ['UnKillableThread']
+2021-02-15 19:52:31 Supervisor   2655520 INFO     worker(2655521) has finished successfully
+2021-02-15 19:52:31 Supervisor   2655520 INFO     worker(2655521) was respawned as worker(2655641)
+```

--- a/examples/9_hanging_threads/consumer.py
+++ b/examples/9_hanging_threads/consumer.py
@@ -1,0 +1,65 @@
+import threading
+import time
+import sergeant
+import logging
+
+
+class Worker(
+    sergeant.worker.Worker,
+):
+    config = sergeant.config.WorkerConfig(
+        name='test_worker',
+        connector=sergeant.config.Connector(
+            type='redis',
+            params={
+                'nodes': [
+                    {
+                        'host': 'localhost',
+                        'port': 6379,
+                        'password': None,
+                        'database': 0,
+                    },
+                ],
+            },
+        ),
+        logging=sergeant.config.Logging(
+            level=logging.INFO,
+            log_to_stdout=True,
+        ),
+        number_of_threads=2,
+        max_tasks_per_run=1,
+    )
+
+    def work(
+        self,
+        task,
+    ):
+        if task.kwargs['param'] == 'first':
+            self.logger.info('param: first')
+
+            def killable_thread():
+                try:
+                    while True:
+                        self.logger.info(f'killable thread: {time.time()}')
+                        time.sleep(1.0)
+                except SystemExit:
+                    self.logger.info('Got a SystemExit. Exiting...')
+
+            def unkillable_thread():
+                while True:
+                    try:
+                        self.logger.info(f'unkillable thread: {time.time()}')
+                        time.sleep(1.0)
+                    except SystemExit:
+                        self.logger.info('Got a SystemExit. Ignoring...')
+
+            threading.Thread(
+                target=killable_thread,
+                daemon=False,
+                name='KillableThread'
+            ).start()
+            threading.Thread(
+                target=unkillable_thread,
+                daemon=False,
+                name='UnKillableThread'
+            ).start()

--- a/examples/9_hanging_threads/producer.py
+++ b/examples/9_hanging_threads/producer.py
@@ -1,0 +1,23 @@
+from . import consumer
+
+
+def main():
+    # Init a worker instance to interact with its API
+    worker = consumer.Worker()
+
+    # Init the worker task queue so we would be able to push tasks to the broker
+    worker.init_broker()
+
+    # Make sure the queue is empty
+    worker.purge_tasks()
+
+    # Produce tasks
+    worker.push_task(
+        kwargs={
+            'param': 'first',
+        },
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/sergeant/slave.py
+++ b/sergeant/slave.py
@@ -81,16 +81,17 @@ def kill_running_background_threads() -> bool:
         if thread is threading.main_thread():
             continue
 
-        ctypes.pythonapi.PyThreadState_SetAsyncExc(
-            ctypes.c_ulong(thread.ident),
-            ctypes.py_object(SystemExit),
-        )
+        if thread.ident:
+            ctypes.pythonapi.PyThreadState_SetAsyncExc(
+                ctypes.c_ulong(thread.ident),
+                ctypes.py_object(SystemExit),
+            )
 
-        thread.join(
-            timeout=2.0,
-        )
-        if thread.is_alive():
-            number_of_unkillable_threads += 1
+            thread.join(
+                timeout=2.0,
+            )
+            if thread.is_alive():
+                number_of_unkillable_threads += 1
 
     return number_of_unkillable_threads == 0
 
@@ -131,6 +132,9 @@ if __name__ == '__main__':
             worker_module_name=args.worker_module,
             worker_class_name=args.worker_class,
         )
+        if not summary:
+            sys.exit(return_code)
+
         summary['return_code'] = return_code
 
         background_threads_killed_successfully = kill_running_background_threads()

--- a/tests/supervisor/workers/worker_abnormal_execution.py
+++ b/tests/supervisor/workers/worker_abnormal_execution.py
@@ -1,0 +1,28 @@
+import sergeant
+
+
+class Worker(
+    sergeant.worker.Worker,
+):
+    config = sergeant.config.WorkerConfig(
+        name='test_worker',
+        connector=sergeant.config.Connector(
+            type='redis',
+            params={
+                'nodes': [
+                    {
+                        'host': 'localhost',
+                        'port': 6379,
+                        'password': None,
+                        'database': 0,
+                    },
+                ],
+            },
+        ),
+        max_tasks_per_run=1,
+    )
+
+    def work_loop(
+        self,
+    ):
+        raise Exception()

--- a/tests/supervisor/workers/worker_hanging_killable_threads_stop.py
+++ b/tests/supervisor/workers/worker_hanging_killable_threads_stop.py
@@ -1,0 +1,51 @@
+import sergeant
+import threading
+import time
+
+
+class Worker(
+    sergeant.worker.Worker,
+):
+    config = sergeant.config.WorkerConfig(
+        name='test_worker',
+        connector=sergeant.config.Connector(
+            type='redis',
+            params={
+                'nodes': [
+                    {
+                        'host': 'localhost',
+                        'port': 6379,
+                        'password': None,
+                        'database': 0,
+                    },
+                ],
+            },
+        ),
+        max_tasks_per_run=1,
+    )
+
+    def initialize(
+        self,
+    ):
+        self.push_task(
+            kwargs={},
+        )
+
+    def work(
+        self,
+        task,
+    ):
+        def killable_thread():
+            try:
+                while True:
+                    time.sleep(1.0)
+            except SystemExit:
+                pass
+
+        threading.Thread(
+            target=killable_thread,
+            daemon=False,
+            name='KillableThread'
+        ).start()
+
+        self.stop()

--- a/tests/supervisor/workers/worker_hanging_killable_threads_success.py
+++ b/tests/supervisor/workers/worker_hanging_killable_threads_success.py
@@ -1,0 +1,49 @@
+import sergeant
+import threading
+import time
+
+
+class Worker(
+    sergeant.worker.Worker,
+):
+    config = sergeant.config.WorkerConfig(
+        name='test_worker',
+        connector=sergeant.config.Connector(
+            type='redis',
+            params={
+                'nodes': [
+                    {
+                        'host': 'localhost',
+                        'port': 6379,
+                        'password': None,
+                        'database': 0,
+                    },
+                ],
+            },
+        ),
+        max_tasks_per_run=1,
+    )
+
+    def initialize(
+        self,
+    ):
+        self.push_task(
+            kwargs={},
+        )
+
+    def work(
+        self,
+        task,
+    ):
+        def killable_thread():
+            try:
+                while True:
+                    time.sleep(1.0)
+            except SystemExit:
+                pass
+
+        threading.Thread(
+            target=killable_thread,
+            daemon=False,
+            name='KillableThread'
+        ).start()


### PR DESCRIPTION
We've been experiencing production issues for a while regarding stalled workers. After a rigorous investigation, we saw there were background threads that kept running. The issue with such threads is that sometimes they were non-daemonic threads, meaning that the Python's interpreter will not exit unless these threads will finish their execution. These threads were stuck in a deadlock and would have never been finished. We've added a background threads protection at the end of the `Slave's` execution. The protection consists of two phases. The first tries to stop the threads mildly by raising a `SystemExit` exception in the threads using an internal Python API, then joining the threads for 2 seconds waiting for the thread to finish. If there are `unkillable` threads left, and `slave` would kill itself with a `SIGKILL` resulting in a non-interruptable exit. 