### PR TITLE
Push Task to Ordered Set

### DIFF
--- a/sergeant/connector/redis.py
+++ b/sergeant/connector/redis.py
@@ -276,7 +276,6 @@ class OrderedSetQueueRedis(
             return regular_items + delayed_items
 
 
-
 class Connector(
     _connector.Connector,
 ):
@@ -463,6 +462,7 @@ class Connector(
             redis_connection=redis_connection,
             name=name,
         )
+
 
 class OrderedSetConnector(
     Connector,

--- a/sergeant/worker.py
+++ b/sergeant/worker.py
@@ -93,6 +93,8 @@ class Worker:
             connector_obj = connector.mongo.Connector(**self.config.connector.params)
         elif self.config.connector.type == connector.redis.Connector.name:
             connector_obj = connector.redis.Connector(**self.config.connector.params)
+        elif self.config.connector.type == connector.redis.OrderedSetConnector.name:
+            connector_obj = connector.redis.OrderedSetConnector(**self.config.connector.params)
         else:
             raise ValueError(f'connector type {self.config.connector.type} is not supported')
 


### PR DESCRIPTION
Description:
enable pushing tasks to ordered sets, to ensure avoiding duplication in queue.
I see this is how the delayed tasks feature is implemented, it could be helpful to have it also as a normal push_task.
